### PR TITLE
Remove mutual exclusivity of `horizontal_`/`vertical_coordinate_pixel` attributes

### DIFF
--- a/src/PDS4_EBT_IngestLDD.xml
+++ b/src/PDS4_EBT_IngestLDD.xml
@@ -984,8 +984,12 @@
       <maximum_occurrences>1</maximum_occurrences>
     </DD_Association>
     <DD_Association>
-      <identifier_reference>XSChoice#</identifier_reference>
       <identifier_reference>vertical_coordinate_pixel</identifier_reference>
+      <reference_type>attribute_of</reference_type>
+      <minimum_occurrences>1</minimum_occurrences>
+      <maximum_occurrences>1</maximum_occurrences>
+     </DD_Association>
+     <DD_Association>
       <identifier_reference>horizontal_coordinate_pixel</identifier_reference>
       <reference_type>attribute_of</reference_type>
       <minimum_occurrences>1</minimum_occurrences>

--- a/src/PDS4_EBT_IngestLDD.xml
+++ b/src/PDS4_EBT_IngestLDD.xml
@@ -936,6 +936,18 @@
       <maximum_occurrences>1</maximum_occurrences>
     </DD_Association>
     <DD_Association>
+      <identifier_reference>vertical_coordinate_pixel</identifier_reference>
+      <reference_type>attribute_of</reference_type>
+      <minimum_occurrences>1</minimum_occurrences>
+      <maximum_occurrences>1</maximum_occurrences>
+    </DD_Association>
+    <DD_Association>
+      <identifier_reference>horizontal_coordinate_pixel</identifier_reference>
+      <reference_type>attribute_of</reference_type>
+      <minimum_occurrences>1</minimum_occurrences>
+      <maximum_occurrences>1</maximum_occurrences>
+    </DD_Association>
+    <DD_Association>
       <identifier_reference>World_Axis</identifier_reference>
       <reference_type>component_of</reference_type>
       <minimum_occurrences>1</minimum_occurrences>
@@ -983,18 +995,6 @@
       <minimum_occurrences>1</minimum_occurrences>
       <maximum_occurrences>1</maximum_occurrences>
     </DD_Association>
-    <DD_Association>
-      <identifier_reference>vertical_coordinate_pixel</identifier_reference>
-      <reference_type>attribute_of</reference_type>
-      <minimum_occurrences>1</minimum_occurrences>
-      <maximum_occurrences>1</maximum_occurrences>
-     </DD_Association>
-     <DD_Association>
-      <identifier_reference>horizontal_coordinate_pixel</identifier_reference>
-      <reference_type>attribute_of</reference_type>
-      <minimum_occurrences>1</minimum_occurrences>
-      <maximum_occurrences>1</maximum_occurrences>
-     </DD_Association>
   </DD_Class>
 
   <DD_Class>


### PR DESCRIPTION
## Summary
As [I mentioned here](https://github.com/pds-data-dictionaries/ldd-ebt/pull/9#discussion_r1248330523), the `vertical_coordinate_pixel` and `horizontal_coordinate_pixel` attributes of the `ebt:World_Axis` class should not be mutually exclusive. Both are needed to describe the point in the image to which a specific world axis position applies.

For example, if the X/Y axes of the image are anything other than perfectly aligned with the RA/Dec axes of the sky, a single given right ascension value won't apply to all the pixels in a row or column, as is implied by specifying only one of `horizontal_coordinate_pixel` or `vertical_coordinate_pixel`. Both pixel coordinates are needed in order to properly associate the position in the image with the position in world coordinates.

This PR removes the `XSChoice#` that restricted each `World_Axis` instance to having only one of these two attributes.

## Test Data and/or Report
Ingest LDD file passes validate and successfully builds locally.
